### PR TITLE
Fix Pytest4.x compatibility errors

### DIFF
--- a/dbfread/test_read_and_length.py
+++ b/dbfread/test_read_and_length.py
@@ -24,19 +24,19 @@ deleted_records = [{u'NAME': u'Deleted Guy',
                     u'BIRTHDATE': datetime.date(1979, 12, 22),
                     u'MEMO': u'Deleted Guy memo'}]
 
-def test_len():
-    assert len(table()) == 2
-    assert len(table().deleted) == 1
+def test_len(table, loaded_table):
+    assert len(table) == 2
+    assert len(table.deleted) == 1
 
-    assert len(loaded_table()) == 2
-    assert len(loaded_table().deleted) == 1
+    assert len(loaded_table) == 2
+    assert len(loaded_table.deleted) == 1
 
-def test_list():
-    assert list(table()) == records
-    assert list(table().deleted) == deleted_records
+def test_list(table, loaded_table):
+    assert list(table) == records
+    assert list(table.deleted) == deleted_records
     
-    assert list(loaded_table()) == records
-    assert list(loaded_table().deleted) == deleted_records
+    assert list(loaded_table) == records
+    assert list(loaded_table.deleted) == deleted_records
 
     # This should not return old style table which was a subclass of list.
-    assert not isinstance(table(), list)
+    assert not isinstance(table, list)

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,6 @@ universal = 1
 
 [easy_install]
 
-[pytest]
+[tool:pytest]
 norecursedirs = build dist examples
 


### PR DESCRIPTION
The next two errors were fixed:
```
[pytest] sections in setup.cfg files should now be named [tool:pytest] to
avoid conflicts with other distutils commands.
```

```
Calling a fixture function directly, as opposed to request them in a test
function, is deprecated.
```

Signed-off-by: Stanislav Levin <slev@altlinux.org>